### PR TITLE
Move ticket creation logic to notifier

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:services_app/notifiers/services_notifier.dart';
+import 'package:services_app/notifiers/ticket_notifier.dart';
 import 'package:services_app/notifiers/theme_notifier.dart';
 import 'package:services_app/screens/home_screen.dart';
 import 'package:services_app/utils/router.dart';
@@ -17,6 +18,7 @@ class MyApp extends StatelessWidget {
         // Aquí puedes agregar otros providers si es necesario
         ChangeNotifierProvider(create: (_) => ThemeNotifier()),
         ChangeNotifierProvider(create: (_) => ServicesNotifier()),
+        ChangeNotifierProvider(create: (_) => TicketNotifier()),
       ],
       builder: (context, _) => MaterialApp(
         title: 'Servicios',

--- a/lib/notifiers/ticket_notifier.dart
+++ b/lib/notifiers/ticket_notifier.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:services_app/services/api.dart';
+
+enum TicketStatus { idle, loading, success, error }
+
+class TicketNotifier with ChangeNotifier {
+  TicketStatus _status = TicketStatus.idle;
+  TicketStatus get status => _status;
+
+  Future<void> createTicket({
+    required String name,
+    required String address,
+    required DateTime date,
+    String? comment,
+    required String serviceDocumentId,
+  }) async {
+    try {
+      _status = TicketStatus.loading;
+      notifyListeners();
+      await Api().createTicket(
+        name: name,
+        address: address,
+        date: date,
+        comment: comment,
+        serviceDocumentId: serviceDocumentId,
+      );
+      _status = TicketStatus.success;
+    } catch (_) {
+      _status = TicketStatus.error;
+      rethrow;
+    } finally {
+      notifyListeners();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add TicketNotifier to handle ticket API calls
- wire TicketNotifier into `main.dart`
- use TicketNotifier in `CreateServiceScreen`
- wrap ticket creation button in a `Selector`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68411cb1f9c8832daf1e278a76db0b6c