### PR TITLE
Add sample tests and API injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,16 @@ Aplicación Flutter que lista servicios obtenidos de una API y permite agendar u
    ```bash
    flutter run
    ```
-4. (Opcional) Ejecuta las pruebas con:
+4. (Opcional) Ejecuta las pruebas unitarias y de widgets con:
 
    ```bash
    flutter test
+   ```
+
+5. (Opcional) Para las pruebas de integración usa:
+
+   ```bash
+   flutter test integration_test
    ```
 
 ## Estructura del proyecto

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -1,0 +1,14 @@
+import 'package:integration_test/integration_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:services_app/main.dart' as app;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('App starts and shows home', (WidgetTester tester) async {
+    app.main();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Servicios'), findsOneWidget);
+  });
+}

--- a/lib/notifiers/services_notifier.dart
+++ b/lib/notifiers/services_notifier.dart
@@ -5,6 +5,9 @@ import 'package:services_app/services/api.dart';
 enum ServiceStatus { loading, success, error }
 
 class ServicesNotifier with ChangeNotifier {
+  ServicesNotifier({Api? api}) : _api = api ?? Api();
+
+  final Api _api;
   List<ServiceModel> _services = [];
   ServiceStatus _status = ServiceStatus.loading;
 
@@ -15,7 +18,7 @@ class ServicesNotifier with ChangeNotifier {
   Future<void> fetchServices() async {
     try {
       _status = ServiceStatus.loading;
-      final services = await Api().getServices();
+      final services = await _api.getServices();
       _services = services;
       _status = ServiceStatus.success;
     } catch (err) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,9 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
+  mocktail: ^1.0.3
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/test/models/service_model_test.dart
+++ b/test/models/service_model_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:services_app/models/service_model.dart';
+
+void main() {
+  test('ServiceModel.fromJson parses values correctly', () {
+    final json = {
+      'id': 1,
+      'documentId': 'doc1',
+      'name': 'Servicio de prueba',
+      'description': 'desc',
+      'price': 10.5,
+      'createdAt': '2024-01-01',
+      'updatedAt': '2024-01-02',
+      'publishedAt': '2024-01-03',
+      'icon': {
+        'id': 1,
+        'documentId': 'img1',
+        'name': 'img.png',
+        'width': 100,
+        'height': 100,
+        'formats': {
+          'thumbnail': {
+            'ext': '.png',
+            'url': 'http://example.com/icon.png',
+            'hash': 'hash',
+            'mime': 'image/png',
+            'name': 'icon',
+            'width': 100,
+            'height': 100,
+            'size': 1.0,
+            'sizeInBytes': 1000,
+          }
+        },
+        'hash': 'hash',
+        'ext': '.png',
+        'mime': 'image/png',
+        'size': 1.0,
+        'url': 'http://example.com/icon.png',
+        'previewUrl': null,
+      },
+      'banner': {
+        'id': 2,
+        'documentId': 'img2',
+        'name': 'banner.png',
+        'width': 200,
+        'height': 200,
+        'formats': {
+          'thumbnail': {
+            'ext': '.png',
+            'url': 'http://example.com/banner.png',
+            'hash': 'hash2',
+            'mime': 'image/png',
+            'name': 'banner',
+            'width': 200,
+            'height': 200,
+            'size': 2.0,
+            'sizeInBytes': 2000,
+          }
+        },
+        'hash': 'hash2',
+        'ext': '.png',
+        'mime': 'image/png',
+        'size': 2.0,
+        'url': 'http://example.com/banner.png',
+        'previewUrl': null,
+      },
+    };
+
+    final model = ServiceModel.fromJson(json);
+
+    expect(model.id, 1);
+    expect(model.documentId, 'doc1');
+    expect(model.name, 'Servicio de prueba');
+    expect(model.price, 10.5);
+    expect(model.icon.formats['thumbnail']!.url,
+        'http://example.com/icon.png');
+  });
+}

--- a/test/notifiers/services_notifier_test.dart
+++ b/test/notifiers/services_notifier_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:services_app/models/service_model.dart';
+import 'package:services_app/notifiers/services_notifier.dart';
+import 'package:services_app/services/api.dart';
+
+class FakeApi extends Api {
+  FakeApi(this.services);
+  final List<ServiceModel> services;
+
+  @override
+  Future<List<ServiceModel>> getServices() async {
+    return services;
+  }
+}
+
+ServiceModel _buildService() => ServiceModel(
+      id: 1,
+      documentId: '1',
+      name: 'Service',
+      description: 'desc',
+      price: 10,
+      createdAt: '2024',
+      updatedAt: '2024',
+      publishedAt: '2024',
+      icon: _media,
+      banner: _media,
+    );
+
+final _format = Format(
+  ext: '.png',
+  url: 'url',
+  hash: 'hash',
+  mime: 'image/png',
+  name: 'img',
+  width: 10,
+  height: 10,
+  size: 1.0,
+  sizeInBytes: 100,
+);
+
+final _media = Media(
+  id: 1,
+  documentId: 'doc',
+  name: 'img.png',
+  width: 10,
+  height: 10,
+  formats: {'thumbnail': _format},
+  hash: 'hash',
+  ext: '.png',
+  mime: 'image/png',
+  size: 1.0,
+  url: 'url',
+  previewUrl: null,
+);
+
+void main() {
+  test('fetchServices updates status and list', () async {
+    final notifier = ServicesNotifier(api: FakeApi([_buildService()]));
+    await notifier.fetchServices();
+
+    expect(notifier.status, ServiceStatus.success);
+    expect(notifier.services.length, 1);
+  });
+}

--- a/test/notifiers/theme_notifier_test.dart
+++ b/test/notifiers/theme_notifier_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:services_app/notifiers/theme_notifier.dart';
+
+void main() {
+  test('ThemeNotifier toggles dark mode', () {
+    final notifier = ThemeNotifier();
+    expect(notifier.isDarkMode, isFalse);
+
+    notifier.isDarkMode = true;
+    expect(notifier.isDarkMode, isTrue);
+  });
+}

--- a/test/screens/home_screen_test.dart
+++ b/test/screens/home_screen_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:services_app/models/service_model.dart';
+import 'package:services_app/notifiers/services_notifier.dart';
+import 'package:services_app/screens/home_screen.dart';
+import 'package:services_app/services/api.dart';
+
+class FakeApi extends Api {
+  FakeApi(this.services);
+  final List<ServiceModel> services;
+
+  @override
+  Future<List<ServiceModel>> getServices() async {
+    return services;
+  }
+}
+
+ServiceModel _buildService(String name) {
+  final format = Format(
+    ext: '.png',
+    url: 'http://example.com/$name.png',
+    hash: 'hash',
+    mime: 'image/png',
+    name: name,
+    width: 48,
+    height: 48,
+    size: 1.0,
+    sizeInBytes: 1000,
+  );
+  final media = Media(
+    id: 1,
+    documentId: 'doc',
+    name: '$name.png',
+    width: 48,
+    height: 48,
+    formats: {'thumbnail': format},
+    hash: 'hash',
+    ext: '.png',
+    mime: 'image/png',
+    size: 1.0,
+    url: 'http://example.com/$name.png',
+    previewUrl: null,
+  );
+  return ServiceModel(
+    id: 1,
+    documentId: '1',
+    name: name,
+    description: 'desc',
+    price: 10,
+    createdAt: '2024',
+    updatedAt: '2024',
+    publishedAt: '2024',
+    icon: media,
+    banner: media,
+  );
+}
+
+void main() {
+  testWidgets('HomeScreen shows service list', (WidgetTester tester) async {
+    final services = [_buildService('Service')];
+    final notifier = ServicesNotifier(api: FakeApi(services));
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ServicesNotifier>.value(
+        value: notifier,
+        child: const MaterialApp(home: HomeScreen()),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Servicios'), findsOneWidget);
+    expect(find.text('Service'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- allow injecting an `Api` into `ServicesNotifier`
- document integration test command
- add model, notifier and widget unit tests
- create a simple integration test example
- update pubspec with testing deps

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68411e376984832db6df1647d166a55b