### PR TITLE
feat: add QR code scanning

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:services_app/notifiers/services_notifier.dart';
 import 'package:services_app/screens/details_screen.dart';
+import 'package:services_app/screens/qr_scan_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -21,6 +22,12 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.pushNamed(context, QRScanScreen.routeName);
+        },
+        child: const Icon(Icons.qr_code_scanner),
+      ),
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/lib/screens/qr_scan_screen.dart
+++ b/lib/screens/qr_scan_screen.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:qr_code_scanner/qr_code_scanner.dart';
+
+class QRScanScreen extends StatefulWidget {
+  const QRScanScreen({super.key});
+
+  static const String routeName = '/qr-scan';
+
+  @override
+  State<QRScanScreen> createState() => _QRScanScreenState();
+}
+
+class _QRScanScreenState extends State<QRScanScreen> {
+  final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');
+  QRViewController? controller;
+  String? qrText;
+
+  @override
+  void reassemble() {
+    super.reassemble();
+    if (Platform.isAndroid) {
+      controller?.pauseCamera();
+    } else if (Platform.isIOS) {
+      controller?.resumeCamera();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Escanear QR'),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            flex: 4,
+            child: QRView(
+              key: qrKey,
+              onQRViewCreated: _onQRViewCreated,
+            ),
+          ),
+          Expanded(
+            flex: 1,
+            child: Center(
+              child: Text(qrText ?? 'Escanea un código QR'),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+
+  void _onQRViewCreated(QRViewController controller) {
+    this.controller = controller;
+    controller.scannedDataStream.listen((scanData) {
+      setState(() {
+        qrText = scanData.code;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    controller?.dispose();
+    super.dispose();
+  }
+}

--- a/lib/utils/router.dart
+++ b/lib/utils/router.dart
@@ -1,9 +1,11 @@
 import 'package:services_app/screens/create_service_screen.dart';
 import 'package:services_app/screens/details_screen.dart';
 import 'package:services_app/screens/home_screen.dart';
+import 'package:services_app/screens/qr_scan_screen.dart';
 
 final router = {
   HomeScreen.routeName: (context) => const HomeScreen(),
   DetailsScreen.routeName: (context) => const DetailsScreen(),
   CreateServiceScreen.routeName: (context) => const CreateServiceScreen(),
+  QRScanScreen.routeName: (context) => const QRScanScreen(),
 };

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   dio: ^5.8.0+1
   provider: ^6.1.5
+  qr_code_scanner: ^1.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add qr_code_scanner dependency
- create QRScanScreen to scan and display codes
- integrate QR scanner route and button on home screen

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae66053714832dbd276d56c4670b0a